### PR TITLE
 change underlying map to a sharded, concurrent map

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -184,6 +184,9 @@ func (this *cache) RunRefresh() error {
 	for key := range this.refreshes {
 		// ensure the entry even exists to be refreshed
 		entry, found := this.entries.Get(key)
+		if entry == nil {
+			continue
+		}
 		if !found {
 			entry.refreshError = refreshErrEntryNotFound
 			continue

--- a/cache.go
+++ b/cache.go
@@ -30,7 +30,6 @@ type Cache interface {
 type cache struct {
 	Params
 
-	//entries   map[string]*cacheEntry
 	entries   ConcurrentMap
 	refreshes chan string
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -16,7 +16,7 @@ var (
 	keySet = []string{key1, key2, key3}
 )
 
-func TestGet(t *testing.T) {
+func TestGetStartWithCacheMiss(t *testing.T) {
 	data := make(map[string]int, 0)
 	params := Params{
 		Loader:             &staticLoader{data: &data},

--- a/cmap.go
+++ b/cmap.go
@@ -34,7 +34,7 @@ type Shard struct {
 func memhash(p unsafe.Pointer, h, s uintptr) uintptr
 
 // NewConcurrentMap creates a new concurrent map
-func NewConcurrentMap(numShards int) ConcurrentMap {
+func NewConcurrentMap(numShards uint32) ConcurrentMap {
 	shards := make([]*Shard, numShards)
 	for i := range shards {
 		shards[i] = &Shard{

--- a/cmap.go
+++ b/cmap.go
@@ -25,7 +25,6 @@ type cmap struct {
 	Shards      []*Shard
 	CountChange chan int
 	Count       int
-	CountLock   sync.RWMutex
 }
 
 // Shard represents a submap with a shared lock
@@ -107,8 +106,6 @@ func (m *cmap) Del(key string) (*cacheEntry, bool) {
 
 // Len returns the length of the concurrent map. TODO: make this constnat-time.
 func (m *cmap) Len() int {
-	m.CountLock.RLock()
-	defer m.CountLock.RUnlock()
 	return m.Count
 }
 
@@ -141,9 +138,7 @@ func (m *cmap) All() chan *KeyVal {
 // This makes cmap.Count eventually consistent (when the channel has been drained).
 func (m *cmap) updateCount() {
 	for delta := range m.CountChange {
-		m.CountLock.Lock()
 		m.Count += delta
-		m.CountLock.Unlock()
 	}
 }
 

--- a/cmap.go
+++ b/cmap.go
@@ -1,0 +1,122 @@
+package lcache
+
+import "sync"
+import "unsafe"
+
+// KeyVal represents the key-value pair of a cache key and a cacheEntry
+type KeyVal struct {
+	key string
+	val *cacheEntry
+}
+
+// ConcurrentMap provides map capabilities that are lock-free on reads and shard-locked on writes.
+type ConcurrentMap interface {
+	Get(key string) (*cacheEntry, bool)
+	Set(key string, val *cacheEntry)
+	Del(key string)
+	Len() int
+	All() chan *KeyVal
+}
+
+// cmap provides a concurrent map
+type cmap struct {
+	Shards []*Shard
+}
+
+// Shard represents a submap with a shared lock
+type Shard struct {
+	m    map[string]interface{}
+	lock sync.RWMutex
+}
+
+//go:noescape
+//go:linkname memhash runtime.memhash
+func memhash(p unsafe.Pointer, h, s uintptr) uintptr
+
+// NewConcurrentMap creates a new concurrent map
+func NewConcurrentMap(numShards int) ConcurrentMap {
+	shards := make([]*Shard, numShards)
+	for i := range shards {
+		shards[i] = &Shard{
+			m:    make(map[string]interface{}),
+			lock: sync.RWMutex{},
+		}
+	}
+	return &cmap{
+		Shards: shards,
+	}
+}
+
+// Shard gets the shard for the given key.
+func (m *cmap) Shard(key string) *Shard {
+	return m.Shards[m.hash(key)]
+}
+
+func (m *cmap) hash(key string) int {
+	hash := uint(memhash(unsafe.Pointer(&key), 0, uintptr(len(key))))
+	// return int(hash % uint64(len(m.Shards)))
+	return jumphash(hash, len(m.Shards))
+}
+
+// Get retrieves the value associated with the key, if it exists.
+func (m *cmap) Get(key string) (*cacheEntry, bool) {
+	shard := m.Shard(key)
+	shard.lock.RLock()
+	defer shard.lock.RUnlock()
+	val, ok := shard.m[key]
+	if val == nil {
+		return nil, ok
+	}
+	return val.(*cacheEntry), ok
+}
+
+// Set sets the key-val pair.
+func (m *cmap) Set(key string, val *cacheEntry) {
+	shard := m.Shard(key)
+	shard.lock.Lock()
+	shard.m[key] = val
+	shard.lock.Unlock()
+}
+
+// Del deletes the key.
+func (m *cmap) Del(key string) {
+	shard := m.Shard(key)
+	shard.lock.Lock()
+	delete(shard.m, key)
+	shard.lock.Unlock()
+}
+
+// Len returns the length of the concurrent map. TODO: make this constnat-time
+func (m *cmap) Len() int {
+	val := 0
+	for _, shard := range m.Shards {
+		val += len(shard.m)
+	}
+	return val
+}
+
+func (m *cmap) All() chan *KeyVal {
+	iter := make(chan *KeyVal)
+	go func() {
+		for _, shard := range m.Shards {
+			for key, val := range shard.m {
+				iter <- &KeyVal{key: key, val: val.(*cacheEntry)}
+			}
+		}
+		close(iter)
+	}()
+	return iter
+}
+
+// ported from https://github.com/ceejbot/jumphash/blob/master/jump.cc#L6-L17
+func jumphash(key uint, buckets int) int {
+	var b, j int
+	b = -1
+	j = 0
+	for j < buckets {
+		b = j
+		key = key*2862933555777941757 + 1
+		j = (b + 1) * (1 << 31) / int(((key >> 33) + 1))
+	}
+	return b
+}

--- a/cmap.go
+++ b/cmap.go
@@ -1,26 +1,31 @@
 package lcache
 
-import "sync"
-import "unsafe"
+import (
+	"sync"
+	"unsafe"
+)
 
 // KeyVal represents the key-value pair of a cache key and a cacheEntry
 type KeyVal struct {
-	key string
-	val *cacheEntry
+	Key string
+	Val *cacheEntry
 }
 
 // ConcurrentMap provides map capabilities that are lock-free on reads and shard-locked on writes.
 type ConcurrentMap interface {
 	Get(key string) (*cacheEntry, bool)
-	Set(key string, val *cacheEntry)
-	Del(key string)
+	Set(key string, val *cacheEntry) (*cacheEntry, bool)
+	Del(key string) (*cacheEntry, bool)
 	Len() int
 	All() chan *KeyVal
 }
 
-// cmap provides a concurrent map
+// cmap provides a concurrent map.
 type cmap struct {
-	Shards []*Shard
+	Shards      []*Shard
+	CountChange chan int
+	Count       int
+	CountLock   sync.RWMutex
 }
 
 // Shard represents a submap with a shared lock
@@ -35,6 +40,7 @@ func memhash(p unsafe.Pointer, h, s uintptr) uintptr
 
 // NewConcurrentMap creates a new concurrent map.
 func NewConcurrentMap(numShards uint32) ConcurrentMap {
+	countChangeChan := make(chan int, 32)
 	shards := make([]*Shard, numShards)
 	for i := range shards {
 		shards[i] = &Shard{
@@ -42,9 +48,12 @@ func NewConcurrentMap(numShards uint32) ConcurrentMap {
 			lock: sync.RWMutex{},
 		}
 	}
-	return &cmap{
-		Shards: shards,
+	ret := &cmap{
+		Shards:      shards,
+		CountChange: countChangeChan,
 	}
+	go ret.updateCount()
+	return ret
 }
 
 // Shard gets the shard for the given key.
@@ -65,53 +74,111 @@ func (m *cmap) Get(key string) (*cacheEntry, bool) {
 }
 
 // Set sets the key-val pair.
-func (m *cmap) Set(key string, val *cacheEntry) {
+func (m *cmap) Set(key string, val *cacheEntry) (*cacheEntry, bool) {
 	shard := m.Shard(key)
 	shard.lock.Lock()
+	oldVal, exists := shard.m[key]
 	shard.m[key] = val
 	shard.lock.Unlock()
+	if !exists {
+		m.CountChange <- 1
+	}
+	if oldVal == nil {
+		return nil, exists
+	}
+	return oldVal.(*cacheEntry), exists
 }
 
 // Del deletes the key.
-func (m *cmap) Del(key string) {
+func (m *cmap) Del(key string) (*cacheEntry, bool) {
 	shard := m.Shard(key)
 	shard.lock.Lock()
+	oldVal, exists := shard.m[key]
 	delete(shard.m, key)
 	shard.lock.Unlock()
+	if exists {
+		m.CountChange <- -1
+	}
+	if oldVal == nil {
+		return nil, exists
+	}
+	return oldVal.(*cacheEntry), exists
 }
 
 // Len returns the length of the concurrent map. TODO: make this constnat-time.
 func (m *cmap) Len() int {
-	val := 0
-	for _, shard := range m.Shards {
-		val += len(shard.m)
-	}
-	return val
+	m.CountLock.RLock()
+	defer m.CountLock.RUnlock()
+	return m.Count
 }
 
 // All returns a channel that sends all key-val pairs in the map.
 func (m *cmap) All() chan *KeyVal {
 	iter := make(chan *KeyVal)
 	go func() {
+		count := 0
 		for _, shard := range m.Shards {
+			// can't send to channel while holding RLock, so buffer the key-value pairs
+			shard.lock.RLock()
+			keyVals := make([]*KeyVal, 0, len(shard.m))
 			for key, val := range shard.m {
-				iter <- &KeyVal{key: key, val: val.(*cacheEntry)}
+				keyVals = append(keyVals, &KeyVal{Key: key, Val: val.(*cacheEntry)})
+			}
+			shard.lock.RUnlock()
+
+			for _, keyVal := range keyVals {
+				count++
+				iter <- keyVal
 			}
 		}
+		println("All(): count:", count)
 		close(iter)
 	}()
 	return iter
 }
 
+// updateCount is meant to be a goroutine and the only one that updates cmap.Count.
+// This makes cmap.Count eventually consistent (when the channel has been drained).
+func (m *cmap) updateCount() {
+	for delta := range m.CountChange {
+		m.CountLock.Lock()
+		m.Count += delta
+		m.CountLock.Unlock()
+	}
+}
+
 // uses memhash for fast hash (not consistent across processes)
 // and jumphash for finding shard index
 func (m *cmap) hash(key string) int {
-	hash := uint(memhash(unsafe.Pointer(&key), 0, uintptr(len(key))))
-	return jumphash(hash, len(m.Shards))
+	var hash uint64
+	keyLen := len(key)
+	if keyLen <= 16 {
+		hash = uint64(memhash(unsafe.Pointer(&key), 0, uintptr(uint64(keyLen))))
+	} else {
+		start := 0
+		for start < keyLen {
+			end := minInt(start+16, keyLen)
+			chunk := key[start:end]
+			hash ^= uint64(memhash(unsafe.Pointer(&chunk), 0, uintptr(uint64(len(chunk)))))
+			start = end
+			if start == keyLen {
+				break
+			}
+		}
+	}
+	bucket := jumphash(hash, len(m.Shards))
+	return bucket
+}
+
+func minInt(n, m int) int {
+	if n < m {
+		return n
+	}
+	return m
 }
 
 // ported from https://github.com/ceejbot/jumphash/blob/master/jump.cc#L6-L17
-func jumphash(key uint, shards int) int {
+func jumphash(key uint64, shards int) int {
 	var b, j int
 	b = -1
 	j = 0

--- a/cmap_test.go
+++ b/cmap_test.go
@@ -12,8 +12,8 @@ import (
 var src = rand.NewSource(time.Now().UnixNano())
 
 const (
-	letterBytes   = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterBytes   = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
+	letterIdxBits = 8                    // 8 bits to represent a letter index
 	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
 	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
 )

--- a/cmap_test.go
+++ b/cmap_test.go
@@ -1,0 +1,67 @@
+package lcache
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+var src = rand.NewSource(time.Now().UnixNano())
+
+const (
+	letterBytes   = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+
+func TestConsistentHash(t *testing.T) {
+	shards := 64
+	iterations := 1000000
+	expectedCount := float64(iterations / shards)
+	fuzzPercent := 0.10
+	delta := float64(expectedCount) * fuzzPercent
+	tally := make([]int, shards)
+	m := NewConcurrentMap(shards)
+
+	for i := 0; i < iterations; i++ {
+		// use static key length to rule out non-uniform distribution of key lengths which might affect hash distribution
+		key := RandStringBytesMaskImprSrcUnsafe(32)
+		hash := (m.(*cmap)).hash(key)
+		tally[hash]++
+	}
+
+	outliers := 0
+	for i, count := range tally {
+		if float64(count) < expectedCount-delta || float64(count) > expectedCount+delta {
+			println(fmt.Sprintf("[%d] expected count was %.0f but got %d", i, expectedCount, count))
+			outliers++
+		}
+	}
+	if outliers > 0 {
+		log.Fatal(fmt.Sprintf("hash distribution was non-uniform: outliers=%d shards=%d iter=%d fuzz=%.2f",
+			outliers, shards, iterations, fuzzPercent))
+	}
+}
+
+// stolen from https://stackoverflow.com/a/31832326
+func RandStringBytesMaskImprSrcUnsafe(n int) string {
+	b := make([]byte, n)
+	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = src.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return *(*string)(unsafe.Pointer(&b))
+}

--- a/cmap_test.go
+++ b/cmap_test.go
@@ -19,9 +19,9 @@ const (
 )
 
 func TestConsistentHash(t *testing.T) {
-	shards := 64
+	var shards uint32 = 64
 	iterations := 1000000
-	expectedCount := float64(iterations / shards)
+	expectedCount := float64(iterations) / float64(shards)
 	fuzzPercent := 0.10
 	delta := float64(expectedCount) * fuzzPercent
 	tally := make([]int, shards)

--- a/eviction.go
+++ b/eviction.go
@@ -17,10 +17,10 @@ func (this *cache) removeLRU() {
 	// we can't actually sample the set of keys at random, but we can iterate and randomly add entries.
 	// fortunately, Go maps return unordered tuples when range'd. Even when no changes to maps are made.
 	// this makes random sampling pretty easy.
-	for k, v := range this.entries {
+	for kv := range this.entries.All() {
 		sample := evictableEntry{
-			key:   k,
-			value: v,
+			key:   kv.key,
+			value: kv.val,
 		}
 
 		// add sample to pool.
@@ -59,5 +59,5 @@ func (this *cache) removeLRU() {
 	this.evictionPoolTop--
 
 	// delete from cache
-	delete(this.entries, oldest.key)
+	this.entries.Del(oldest.key)
 }

--- a/eviction.go
+++ b/eviction.go
@@ -19,8 +19,8 @@ func (this *cache) removeLRU() {
 	// this makes random sampling pretty easy.
 	for kv := range this.entries.All() {
 		sample := evictableEntry{
-			key:   kv.key,
-			value: kv.val,
+			key:   kv.Key,
+			value: kv.Val,
 		}
 
 		// add sample to pool.
@@ -31,6 +31,9 @@ func (this *cache) removeLRU() {
 
 			// pool's full. Find the oldest entry, replace. Otherwise discard.
 			for z, entry := range this.evictionPool {
+				if entry.value == nil || sample.value == nil {
+					continue
+				}
 				if entry.value.lastUsed.After(sample.value.lastUsed) {
 					this.evictionPool[z] = sample
 					break
@@ -48,6 +51,9 @@ func (this *cache) removeLRU() {
 
 	// find oldest entry in pool
 	for z, entry := range this.evictionPool {
+		if entry.value == nil || oldest.value == nil {
+			continue
+		}
 		if entry.value.lastUsed.Before(oldest.value.lastUsed) {
 			oldest = entry
 			removableIdx = z


### PR DESCRIPTION
`TestGetSetRaceCondition` now passes and `TestConsistentHash` ensures < 10% bias (for 64 shards and 1M random, fixed-length keys).